### PR TITLE
Add hoverhints.nvim plugin

### DIFF
--- a/after/plugin/hoverhints.rc.lua
+++ b/after/plugin/hoverhints.rc.lua
@@ -1,0 +1,5 @@
+local status, hoverhints = pcall(require, 'hoverhints')
+if not status then return end
+
+hoverhints.setup{}
+

--- a/after/plugin/null-ls-rc.lua
+++ b/after/plugin/null-ls-rc.lua
@@ -6,7 +6,7 @@ null_ls.setup {
     if client.server_capabilities.documentFormattingProvider then
       vim.api.nvim_command [[augroup Format]]
       vim.api.nvim_command [[autocmd! * <buffer>]]
-      vim.api.nvim_command [[autocmd BufWritePre <buffer> lua vim.lsp.buf.formattion_seq_sync()]]
+      vim.api.nvim_command [[autocmd BufWritePre <buffer> lua vim.lsp.buf.formattion_seq_sync(nil, 10000)]]
       vim.api.nvim_command [[augroup END]]
     end
   end,
@@ -14,6 +14,9 @@ null_ls.setup {
     null_ls.builtins.diagnostics.eslint_d.with({
       diagnostics_format = "[eslint] #{m}\n(#{c})"
     }),
-    null_ls.builtins.diagnostics.fish,
+    null_ls.builtins.diagnostics.zsh,
+    null_ls.builtins.completion.spell.with({
+      diagnostics_format = "[#{c}] #{m}\n(#{s})"
+    }),
   }
 }

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -7,6 +7,7 @@ end
 vim.cmd [[packadd packer.nvim]]
 
 packer.startup(function(use)
+  use 'soulis-1256/hoverhints.nvim'
   use 'goolord/alpha-nvim' --background
   use 'wbthomason/packer.nvim'
   use {


### PR DESCRIPTION
**Modification :**
Before, I didn't check for spelling, so I felt uncomfortable. However, after applying this plugin, I will be able to catch incorrect spellings

**Demos:**
![checking-spell](https://github.com/jihwooon/nVim-Ide/assets/68071599/acffb00d-2e4e-4637-bf84-9f4d9df552a4)


